### PR TITLE
fix(flush-sets): avoids attempting to send more than one data type to the same metric

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -142,7 +142,73 @@ function millisecondsSince(start) {
 
 InfluxdbBackend.prototype.log = function (msg) {
   util.log('[influxdb] ' + msg);
-}
+};
+
+InfluxdbBackend.prototype.logResponse = function (msg, response) {
+  var output = '' + msg;
+
+  if (output === '') {
+    output = 'response';
+  }
+
+  output = JSON.stringify(output);
+
+  if (response !== null && typeof response === 'object') {
+    // build status code line
+    var temp = '';
+
+    if (typeof response.statusCode === 'number' && response.statusCode > 0) {
+      temp += response.statusCode;
+    }
+
+    output += ' ' + JSON.stringify(temp);
+
+    // build status text
+    temp = '';
+
+    if (typeof response.statusText === 'string' && response.statusText !== '') {
+      temp += response.statusText
+    }
+
+    output += ' ' + JSON.stringify(temp);
+
+    // build method + address
+    temp = '';
+
+    if (response.request !== null && typeof response.request === 'object') {
+      if (typeof response.request.method === 'string' && response.request.method !== '') {
+          temp += response.request.method;
+      }
+
+      if (typeof response.request.url === 'string' && response.request.url !== '') {
+        if (temp !== '') {
+          temp += ' ';
+        }
+
+        temp += response.request.url;
+      }
+    }
+
+    output += ' ' + JSON.stringify(temp);
+
+    // build headers
+    temp = [];
+
+    if (response.headers !== null && typeof response.headers === 'object') {
+      for (var key in response.headers) {
+        if (!response.headers.hasOwnProperty(key)) {
+          continue;
+        }
+
+        temp.push('' + key + ' = ' + response.headers[key]);
+      }
+    }
+
+    output += ' ' +JSON.stringify(temp.join('; '));
+  }
+
+  this.log(output);
+};
 
 InfluxdbBackend.prototype.logDebug = function (msg) {
   if (this.debug) {
@@ -156,7 +222,7 @@ InfluxdbBackend.prototype.logDebug = function (msg) {
 
     util.log('[influxdb] (DEBUG) ' + string);
   }
-}
+};
 
 /**
  * Flush strategy handler
@@ -565,7 +631,7 @@ InfluxdbBackend.prototype.httpPOST_v14 = function (points) {
     self.influxdbStats.httpResponseTime = millisecondsSince(startTime);
 
     if (status >= 400) {
-      self.log(protocolName + ' Error: ' + status);
+      self.logResponse(protocolName + ' Error', res);
     }
   });
 

--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -264,9 +264,48 @@ InfluxdbBackend.prototype.processFlush = function (timestamp, metrics) {
   }
 
   for (set in sets) {
-    sets[set].map(function (v) {
-      points.push(self.assembleEvent(set, [{value: v, time: timestamp,type:"set"}]));
-    })
+    // influxdb only allows one type per measurement per shard - check for any non-int values
+    var nonIntInSet = false;
+    for (var i = 0; i < sets[set].length; i++) {
+      var setValueStr = '' + sets[set][i]; // take the string value for checking...
+      var setValueInt = parseInt(setValueStr); // convert to int (well... float...)
+      // and check it's sane
+      if (!isFinite(setValueInt) || isNaN(setValueInt)) {
+        nonIntInSet = true;
+        break;
+      }
+      // convert setValueInt back to a string
+      setValueInt = '' + setValueInt;
+      // compare with the original, which is difficult because javascript numbers == float :(
+      if (setValueInt.length !== setValueStr.length) {
+        nonIntInSet = true;
+        break;
+      }
+      for (var j = 0; j < setValueStr.length; j++) {
+        var setValueStrChar = setValueStr.charAt(j);
+        // we only check the first 5 chars for exact match, after that we just check if numeric
+        if (j >= 5) {
+          if (setValueStrChar < '0' || setValueStrChar > '9') {
+            nonIntInSet = true;
+            break;
+          }
+        } else {
+          if (setValueInt.charAt(j) !== setValueStrChar) {
+            nonIntInSet = true;
+            break;
+          }
+        }
+      }
+      if (nonIntInSet) {
+        break;
+      }
+    }
+    if (!nonIntInSet) { // only add the original set values if they are all ints
+      sets[set].map(function (v) {
+        points.push(self.assembleEvent(set, [{value: v, time: timestamp,type:"set"}]));
+      });
+    }
+    // add the actual count
     points.push(self.assembleEvent(set , [{value: sets[set].length, time: timestamp,type:"set_count"}]));
   }
 


### PR DESCRIPTION
I am sending UUID values in a set, in order to get a count of running instances. This currently spams 400 logs / may never work (depending on what is the first value seen by influx db, a string or an int).

This PR adds a log method for the response details on v1.4 flush error (outputs one line, contains headers, which contains influxdb error messages, very useful), and fixes the issue with sending more than one type of measurement by verifying that all values in the set will actually be sent as valid integers / are safe to send, before actually sending them (excluding them all if they contain one or more non-integer value, for example).