### PR TITLE
fix(influx-v1.4-flush): debug log the stats flush to avoid spam

### DIFF
--- a/lib/influxdb.js
+++ b/lib/influxdb.js
@@ -554,7 +554,7 @@ InfluxdbBackend.prototype.httpPOST_v14 = function (points) {
   };
 
   var req = self.protocol.request(options);
-  console.log(options);
+  self.logDebug(JSON.stringify(options));
   req.on('socket', function (res) {
     startTime = process.hrtime();
   });
@@ -587,7 +587,7 @@ InfluxdbBackend.prototype.httpPOST_v14 = function (points) {
     var size = (self.influxdbStats.payloadSize / 1024).toFixed(2);
     return 'Payload size ' + size + ' KB';
   });
-  console.log(payload);
+  self.logDebug(payload);
   req.write(payload);
   req.end();
 }


### PR DESCRIPTION
Replaces `console.log` calls spamming request options + payloads with the `self.logDebug` method.